### PR TITLE
Refactor events queue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ pyflakes==3.0.1
 pytest==7.3.2
 pytest-cov==4.1.0
 pytest-custom-exit-code==0.3.0
+pytest-mock==3.11.1
 python-dateutil==2.8.2
 pytz==2023.3
 six==1.16.0

--- a/tests/data_handler/test_data_handler.py
+++ b/tests/data_handler/test_data_handler.py
@@ -1,14 +1,22 @@
 from datetime import datetime
 
 import pytest
+from unittest.mock import MagicMock, call, ANY
 
 from tradeprobe.data_handler import CSVDataHandler
-from tradeprobe.events import OLHCVIMarketEvent
+from tradeprobe.events import OLHCVIMarketEvent, EventQueue
 
 
 @pytest.fixture
 def csv_data_handler():
     return CSVDataHandler("./tests/data_handler", {'AAPL', 'META'})
+
+
+@pytest.fixture
+def mock_event_queue(mocker):
+    mock_queue = MagicMock()
+    mocker.patch('tradeprobe.events.EventQueue.put', side_effect=mock_queue.put)
+    return mock_queue
 
 
 class TestCSVDataHandler:
@@ -18,34 +26,38 @@ class TestCSVDataHandler:
     def test_get_current_tick(self, csv_data_handler):
         assert csv_data_handler.get_current_tick() == datetime(2022, 6, 15)
 
-    def test_get_bar(self, csv_data_handler):
-        events = csv_data_handler.get_bars()
-        assert OLHCVIMarketEvent(timestamp=datetime(2022, 6, 15),
-                                 symbol='META',
-                                 open=167.199997,
-                                 high=172.160004,
-                                 low=163.979996,
-                                 close=169.350006,
-                                 volume=30008300) in events
-        assert OLHCVIMarketEvent(timestamp=datetime(2022, 6, 15),
-                                 symbol='AAPL',
-                                 open=134.289993,
-                                 high=137.339996,
-                                 low=132.160004,
-                                 close=135.429993,
-                                 volume=91533000) in events
-        events = csv_data_handler.get_bars()
-        assert OLHCVIMarketEvent(timestamp=datetime(2022, 6, 16),
-                                 symbol='META',
-                                 open=163.720001,
-                                 high=165.080002,
-                                 low=159.610001,
-                                 close=160.869995,
-                                 volume=26944100) in events
-        assert OLHCVIMarketEvent(timestamp=datetime(2022, 6, 16),
-                                 symbol='AAPL',
-                                 open=132.080002,
-                                 high=132.389999,
-                                 low=129.039993,
-                                 close=130.059998,
-                                 volume=108123900) in events
+    def test_get_bar(self, csv_data_handler, mock_event_queue):
+        csv_data_handler.get_bars()
+        mock_event_queue.put.assert_has_calls(
+            [call(OLHCVIMarketEvent(timestamp=datetime(2022, 6, 15),
+                                    symbol='META',
+                                    open=167.199997,
+                                    high=172.160004,
+                                    low=163.979996,
+                                    close=169.350006,
+                                    volume=30008300), block=ANY),
+             call(OLHCVIMarketEvent(timestamp=datetime(2022, 6, 15),
+                                    symbol='AAPL',
+                                    open=134.289993,
+                                    high=137.339996,
+                                    low=132.160004,
+                                    close=135.429993,
+                                    volume=91533000), block=ANY)],
+            any_order=True)
+
+        csv_data_handler.get_bars()
+        mock_event_queue.put.assert_has_calls([call(OLHCVIMarketEvent(timestamp=datetime(2022, 6, 16),
+                                                                      symbol='META',
+                                                                      open=163.720001,
+                                                                      high=165.080002,
+                                                                      low=159.610001,
+                                                                      close=160.869995,
+                                                                      volume=26944100), block=ANY),
+                                               call(OLHCVIMarketEvent(timestamp=datetime(2022, 6, 16),
+                                                                      symbol='AAPL',
+                                                                      open=132.080002,
+                                                                      high=132.389999,
+                                                                      low=129.039993,
+                                                                      close=130.059998,
+                                                                      volume=108123900), block=ANY)],
+                                              any_order=True)

--- a/tests/events/test_event_queue.py
+++ b/tests/events/test_event_queue.py
@@ -1,0 +1,47 @@
+import unittest
+from datetime import time, datetime
+from queue import Queue
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from tradeprobe.events import EventQueue, Event
+
+
+@pytest.fixture
+def event_queue():
+    return EventQueue()
+
+
+class TestEventQueue(unittest.TestCase):
+    # Most things don't need to be tested since it uses a standard
+    # python queue.
+
+    def test_singleton_instance(self):
+        queue1 = EventQueue()
+        queue2 = EventQueue()
+
+        self.assertIs(queue1, queue2)
+        self.assertIsInstance(queue1, Queue)
+        self.assertIsInstance(queue2, Queue)
+
+    def test_queue_operations(self):
+        mock_event = MagicMock(spec=Event)
+        event1: Event = mock_event()
+        event2: Event = mock_event()
+
+        with patch('tradeprobe.events.Event', return_value=mock_event):
+            queue = EventQueue()
+
+            queue.put(event1)
+            queue.put(event2)
+
+            self.assertEqual(queue.qsize(), 2)
+            self.assertFalse(queue.empty())
+
+            event1 = queue.get()
+            event2 = queue.get()
+
+            self.assertEqual(event1, event1)
+            self.assertEqual(event2, event2)
+            self.assertTrue(queue.empty())

--- a/tradeprobe/data_handler.py
+++ b/tradeprobe/data_handler.py
@@ -123,7 +123,7 @@ class CSVDataHandler(DataHandler):
                 pass
             else:
                 if event is not None:
-                    self.event_queue.put_event(event)
+                    self.event_queue.put_nowait(event)
 
     def get_symbol_list(self) -> Set[str]:
         """Get the list of available symbols."""

--- a/tradeprobe/data_handler.py
+++ b/tradeprobe/data_handler.py
@@ -6,7 +6,7 @@ from typing import List, Set, Generator, Any, Iterable
 import pandas as pd
 from pandas import Series
 
-from tradeprobe.events import OLHCVIMarketEvent, MarketEvent
+from tradeprobe.events import OLHCVIMarketEvent, MarketEvent, EventQueue
 
 
 class DataHandler(object):
@@ -16,8 +16,11 @@ class DataHandler(object):
 
     __metaclass__ = ABCMeta
 
+    def __init__(self):
+        self.event_queue: EventQueue = EventQueue()
+
     @abstractmethod
-    def get_bars(self) -> List[MarketEvent]:
+    def get_bars(self) -> None:
         """Get the next available bar from the data source."""
         raise NotImplementedError("Implement get_next_bar().")
 
@@ -110,9 +113,8 @@ class CSVDataHandler(DataHandler):
                                     close=i[1][3],
                                     volume=i[1][5])
 
-    def get_bars(self) -> List[MarketEvent]:
+    def get_bars(self) -> None:
         """Get the next available bar from the data source."""
-        events: List[MarketEvent] = []
         for symbol in self.symbol_list:
             try:
                 event = next(self._get_next_bar(symbol))
@@ -121,8 +123,7 @@ class CSVDataHandler(DataHandler):
                 pass
             else:
                 if event is not None:
-                    events.append(event)
-        return events
+                    self.event_queue.put_event(event)
 
     def get_symbol_list(self) -> Set[str]:
         """Get the list of available symbols."""

--- a/tradeprobe/data_handler.py
+++ b/tradeprobe/data_handler.py
@@ -16,7 +16,7 @@ class DataHandler(object):
 
     __metaclass__ = ABCMeta
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.event_queue: EventQueue = EventQueue()
 
     @abstractmethod

--- a/tradeprobe/events.py
+++ b/tradeprobe/events.py
@@ -86,8 +86,10 @@ class EventQueue:
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super().__new__()
-            cls._instance.queue = Queue()
         return cls._instance
+
+    def __init__(self):
+        self.queue = Queue()
 
     def put_event(self, event: Event):
         self.queue.put_nowait(event)

--- a/tradeprobe/events.py
+++ b/tradeprobe/events.py
@@ -1,3 +1,4 @@
+from asyncio import Queue
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
@@ -77,3 +78,19 @@ class FillEvent(Event):
     def __post_init__(self):
         if self.quantity < 0:
             raise ValueError("The order quantity must be non-negative.")
+
+
+class EventQueue:
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__()
+            cls._instance.queue = Queue()
+        return cls._instance
+
+    def put_event(self, event: Event):
+        self.queue.put_nowait(event)
+
+    def get_event(self) -> Event:
+        return self.queue.get_nowait()

--- a/tradeprobe/events.py
+++ b/tradeprobe/events.py
@@ -1,4 +1,4 @@
-from asyncio import Queue
+from queue import Queue
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
@@ -80,19 +80,10 @@ class FillEvent(Event):
             raise ValueError("The order quantity must be non-negative.")
 
 
-class EventQueue:
+class EventQueue(Queue):
     _instance = None
 
     def __new__(cls):
         if cls._instance is None:
-            cls._instance = super().__new__()
+            cls._instance = super(EventQueue, cls).__new__(cls)
         return cls._instance
-
-    def __init__(self):
-        self.queue = Queue()
-
-    def put_event(self, event: Event):
-        self.queue.put_nowait(event)
-
-    def get_event(self) -> Event:
-        return self.queue.get_nowait()

--- a/tradeprobe/portfolio.py
+++ b/tradeprobe/portfolio.py
@@ -1,7 +1,61 @@
-class Portfolio:
+from abc import ABCMeta, abstractmethod
+
+from tradeprobe.events import Event, EventQueue
+
+
+class Portfolio(object):
     """
-    Portfolio for managing assets.
+    An abstract class to hold the position and market value of
+    all instruments at the resolution of a bar.
     """
 
-    def __init__(self):
-        pass
+    __metaclass__ = ABCMeta
+
+    def __init__(self, initial_capital=100000):
+        self.initial_capital = initial_capital
+        self.event_queue = EventQueue()
+
+    @abstractmethod
+    def update_on_signal(self, event: Event):
+        """
+        Acts on a signal event to generate orders.
+        """
+        raise NotImplementedError("Implement update_on_signal()")
+
+    @abstractmethod
+    def update_on_fill(self, event: Event):
+        """
+        Update the portfolio's current position based on fill events.
+        """
+        raise NotImplementedError("Implement update_on_fill()")
+
+
+class NaivePortfolio(Portfolio):
+    """
+    A Portfolio that will send order to a brokerage with a constant
+    quantity and size.
+
+    This includes no risk management or position sizing and should
+    not be used in practice.
+
+    It is useful for testing simpler strategies, such as BuyAndHoldStrategy.
+    """
+
+    def __init__(self, initial_capital=100000):
+        super().__init__(initial_capital)
+        self.current_positions = {}
+        self.current_holdings = {}
+
+    @abstractmethod
+    def update_on_signal(self, event: Event):
+        """
+        Acts on a signal event to generate orders.
+        """
+        raise NotImplementedError("Implement update_on_signal()")
+
+    @abstractmethod
+    def update_on_fill(self, event: Event):
+        """
+        Update the portfolio's current position based on fill events.
+        """
+        raise NotImplementedError("Implement update_on_fill()")

--- a/tradeprobe/strategy.py
+++ b/tradeprobe/strategy.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from typing import List
 
-from tradeprobe.events import SignalEvent
+from tradeprobe.events import SignalEvent, EventQueue
 
 
 class Strategy:
@@ -12,6 +12,9 @@ class Strategy:
     """
 
     __metaclass__ = ABCMeta
+
+    def __init__(self):
+        self.event_queue = EventQueue()
 
     @abstractmethod
     def calculate_signals(self) -> List[SignalEvent]:

--- a/tradeprobe/trading_engine.py
+++ b/tradeprobe/trading_engine.py
@@ -27,7 +27,7 @@ class TradingEngine:
 
             while True:
                 try:
-                    match self.event_queue.get_event().__class__.__name__:
+                    match self.event_queue.get_nowait().__class__.__name__:
                         case 'MarketEvent':
                             pass
                         case 'SignalEvent':

--- a/tradeprobe/trading_engine.py
+++ b/tradeprobe/trading_engine.py
@@ -1,9 +1,8 @@
 import queue
-from multiprocessing import Queue
 
 from tradeprobe.broker import Broker
 from tradeprobe.data_handler import DataHandler
-from tradeprobe.events import Event, EventQueue
+from tradeprobe.events import EventQueue
 from tradeprobe.portfolio import Portfolio
 
 

--- a/tradeprobe/trading_engine.py
+++ b/tradeprobe/trading_engine.py
@@ -3,7 +3,7 @@ from multiprocessing import Queue
 
 from tradeprobe.broker import Broker
 from tradeprobe.data_handler import DataHandler
-from tradeprobe.events import Event
+from tradeprobe.events import Event, EventQueue
 from tradeprobe.portfolio import Portfolio
 
 
@@ -19,20 +19,16 @@ class TradingEngine:
         self.end_datetime = end_datetime
         self.current_datetime = self.start_datetime
 
-        self.event_queue: Queue[Event] = Queue()
-
-    def register_event(self, event: Event):
-        self.event_queue.put_nowait(event)
+        self.event_queue: EventQueue = EventQueue()
 
     def run(self):
         """The main loop for handling events."""
         while self.current_datetime < self.end_datetime:
-            [self.event_queue.put_nowait(bar) for bar in self.data_handler.get_bars()]
             self.current_datetime = self.data_handler.get_current_tick()
 
             while True:
                 try:
-                    match self.event_queue.get_nowait().__class__.__name__:
+                    match self.event_queue.get_event().__class__.__name__:
                         case 'MarketEvent':
                             pass
                         case 'SignalEvent':


### PR DESCRIPTION
Use a singleton design pattern as it only makes sense to have one event queue for all classes. This allows the classes to contain a reference to the queue without having to pass it to the class.